### PR TITLE
fixed(view): the bottom cell of the TableView was not being displayed

### DIFF
--- a/Primal/UIKit/Settings/SubControllers/SettingsNotificationsViewController.swift
+++ b/Primal/UIKit/Settings/SubControllers/SettingsNotificationsViewController.swift
@@ -44,7 +44,7 @@ final class SettingsNotificationsViewController: UIViewController, Themeable {
         
         view.addSubview(table)
         table.pinToSuperview(edges: [.leading, .top], safeArea: true).pinToSuperview(edges: .trailing, padding: 6)
-        table.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor).isActive = true
+        table.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -80).isActive = true
         
         table.backgroundColor = .background
         table.delegate = self


### PR DESCRIPTION
- location: Primal/UIKit/Settings/SubControllers/SettingsNotificationsViewController.swift
- fixed: the bottom cell of the TableView was not being displayed after scrolling to the bottom.
- version: 0.31.6
- build: 1