### PR TITLE
Fix live event comment tagging to use creator universal ID

### DIFF
--- a/Primal/Common/Nostr/NostrObject+Extra.swift
+++ b/Primal/Common/Nostr/NostrObject+Extra.swift
@@ -366,7 +366,7 @@ extension NostrObject {
     static func liveComment(live: ProcessedLiveEvent, comment: String) -> NostrObject? {
         let relay = IdentityManager.instance.userRelays?.first(where: { $0.value.write })?.key ?? ""
         return createNostrObject(content: comment, kind: NostrKind.liveComment.rawValue, tags: [
-            ["a", live.universalID, relay, "root"],
+            ["a", live.creatorUniversalID, relay, "root"],
             ["client", "Primal-iOS-App"]
         ])
     }

--- a/Primal/State/Managers/LiveEventManager.swift
+++ b/Primal/State/Managers/LiveEventManager.swift
@@ -87,6 +87,10 @@ extension ProcessedLiveEvent: MetadataCoding {
         "\(NostrKind.live.rawValue):\(pubkey):\(dTag)"
     }
     
+    var creatorUniversalID: String {
+        "\(NostrKind.live.rawValue):\(creatorPubkey):\(dTag)"
+    }
+    
     func noteId() -> String {
         var metadata = Metadata()
         let hint = RelayHintManager.instance.getRelayHint(universalID)


### PR DESCRIPTION
- Add creatorUniversalID computed property to ProcessedLiveEvent
- Update live comment creation to use creatorUniversalID instead of universalID for proper event referencing