### PR TITLE
Fix breaking changes in new remote signer lib

### DIFF
--- a/Primal/Scenes/RemoteSigner/RemoteSignerActiveSessionsController.swift
+++ b/Primal/Scenes/RemoteSigner/RemoteSignerActiveSessionsController.swift
@@ -210,7 +210,7 @@ class RemoteSignerSessionSelectionButton: MyButton {
         }
     }
     
-    init(user: ParsedUser, session: AppSession) {
+    init(user: ParsedUser, session: RemoteAppSession) {
         super.init(frame: .zero)
         
         let nameSuperStack = UIStackView(axis: .vertical, [nameLabel, nipLabel])

--- a/Primal/Scenes/RemoteSigner/RemoteSignerDisclosureController.swift
+++ b/Primal/Scenes/RemoteSigner/RemoteSignerDisclosureController.swift
@@ -16,8 +16,8 @@ class RemoteSignerDisclosureController: UIViewController {
     
     let designHeight: CGFloat = 556
     
-    let session: AppSession
-    init(session: AppSession) {
+    let session: RemoteAppSession
+    init(session: RemoteAppSession) {
         self.session = session
         super.init(nibName: nil, bundle: nil)
         

--- a/Primal/Scenes/Settings/SubControllers/InputControllers/SettingsEditConnectionName.swift
+++ b/Primal/Scenes/Settings/SubControllers/InputControllers/SettingsEditConnectionName.swift
@@ -11,8 +11,8 @@ import PrimalShared
 final class SettingsEditConnectionName: UIViewController, Themeable {
     let valueInput = UITextField()
     
-    let connection: AppConnection
-    init(connection: AppConnection) {
+    let connection: RemoteAppConnection
+    init(connection: RemoteAppConnection) {
         self.connection = connection
         super.init(nibName: nil, bundle: nil)
         

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/AppController/RemoteSignerConnectionCell.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/AppController/RemoteSignerConnectionCell.swift
@@ -45,7 +45,7 @@ final class RemoteSignerConnectionCell: UITableViewCell {
         stack.setCustomSpacing(20, after: titleLabel)
     }
 
-    func configure(connection: AppConnection, user: ParsedUser) {
+    func configure(connection: RemoteAppConnection, user: ParsedUser) {
         activeDot.backgroundColor = connection.autoStart ? .init(rgb: 0x66E205) : .foreground5
         
         iconView.kf.setImage(with: URL(string: connection.image ?? ""), placeholder: connection.defaultImage(size: 20))

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/AppController/RemoteSignerConnectionInfoActionCell.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/AppController/RemoteSignerConnectionInfoActionCell.swift
@@ -78,7 +78,7 @@ final class RemoteSignerConnectionInfoActionCell: UITableViewCell {
         }), for: .touchUpInside)
     }
 
-    func configure(connection: AppConnection, lastStart: Date?, isActive: Bool, delegate: RemoteSignerConnectionInfoActionCellDelegate?) {
+    func configure(connection: RemoteAppConnection, lastStart: Date?, isActive: Bool, delegate: RemoteSignerConnectionInfoActionCellDelegate?) {
         self.delegate = delegate
         
         iconView.kf.setImage(with: URL(string: connection.image ?? ""), placeholder: connection.defaultImage(size: 48))

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/AppController/RemoteSignerConnectionSessionCell.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/AppController/RemoteSignerConnectionSessionCell.swift
@@ -43,7 +43,7 @@ final class RemoteSignerConnectionSessionCell: UITableViewCell {
         formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy h:mm a")
     }
 
-    func configure(session: AppSession) {
+    func configure(session: RemoteAppSession) {
         iconView.kf.setImage(with: URL(string: session.image ?? ""), placeholder: session.defaultImage(size: 20))
         
         titleLabel.text = formatter.string(from: .init(timeIntervalSince1970: TimeInterval(session.sessionStartedAt)))

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/Permissions/RemoteSignerConnectionInfoCell.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/Permissions/RemoteSignerConnectionInfoCell.swift
@@ -46,7 +46,7 @@ final class RemoteSignerConnectionInfoCell: UITableViewCell {
         formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy h:mm a")
     }
 
-    func configure(connection: AppConnection, lastStart: Date?) {
+    func configure(connection: RemoteAppConnection, lastStart: Date?) {
         iconView.kf.setImage(with: URL(string: connection.image ?? ""), placeholder: connection.defaultImage(size: 48))
         titleLabel.text = connection.name
         

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/Permissions/RemoteSignerPermissionEditCell.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/Cells/Permissions/RemoteSignerPermissionEditCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import PrimalShared
 
 protocol RemoteSignerPermissionEditCellDelegate: AnyObject {
-    func remoteSignerPermissionEditCell(_ cell: RemoteSignerPermissionEditCell, didSelect action: PermissionAction)
+    func remoteSignerPermissionEditCell(_ cell: RemoteSignerPermissionEditCell, didSelect action: AppPermissionAction)
 }
 
 final class RemoteSignerPermissionEditCell: UITableViewCell {
@@ -47,12 +47,12 @@ final class RemoteSignerPermissionEditCell: UITableViewCell {
         picker.addAction(.init(handler: { [weak self] _ in
             guard let self else { return }
             let value = picker.selectedSegmentIndex
-            let action: PermissionAction = value == 0 ? .approve : (value == 1 ? .deny : .ask)
+            let action: AppPermissionAction = value == 0 ? .approve : (value == 1 ? .deny : .ask)
             delegate?.remoteSignerPermissionEditCell(self, didSelect: action)
         }), for: .valueChanged)
     }
 
-    func configure(permission: AppPermissionGroup, connection: AppConnection, delegate: RemoteSignerPermissionEditCellDelegate?) {
+    func configure(permission: AppPermissionGroup, connection: RemoteAppConnection, delegate: RemoteSignerPermissionEditCellDelegate?) {
         self.delegate = delegate
         
         titleLabel.text = permission.title

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/SettingsConnectedAppController.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/SettingsConnectedAppController.swift
@@ -18,11 +18,11 @@ class SettingsConnectedAppController: UIViewController {
     }
     
     enum TableItem: Hashable {
-        case mainInfo(AppConnection, lastSession: AppSession?)
+        case mainInfo(RemoteAppConnection, lastSession: RemoteAppSession?)
         case autoStart(Bool)
         case trust(TrustLevel, Bool)
         case permissionDetails
-        case session(AppSession)
+        case session(RemoteAppSession)
         
         var cellId: String {
             switch self {
@@ -37,16 +37,16 @@ class SettingsConnectedAppController: UIViewController {
     
     var cancellables: Set<AnyCancellable> = []
     
-    @Published var items: [AppConnection] = []
+    @Published var items: [RemoteAppConnection] = []
     
     let dataSource: UITableViewDiffableDataSource<TableSections, TableItem>
     
     let tableView = UITableView(frame: .zero, style: .insetGrouped)
     
     let connectionID: String
-    let connection: AppConnection
+    let connection: RemoteAppConnection
     
-    init(appConnection: AppConnection) {
+    init(appConnection: RemoteAppConnection) {
         connection = appConnection
         connectionID = appConnection.clientPubKey
         var wSelf: SettingsConnectedAppController?
@@ -103,7 +103,7 @@ class SettingsConnectedAppController: UIViewController {
             RemoteSignerManager.instance.sessionRepo.observeSessionsByClientPubKey(clientPubKey: connectionID).toPublisher(),
             RemoteSignerManager.instance.connectionRepo.observeConnection(clientPubKey: connectionID).toPublisher()
         )
-        .map { ($0.0 as [AppSession], $0.1) }
+        .map { ($0.0 as [RemoteAppSession], $0.1) }
         .debounce(for: 0.2, scheduler: DispatchQueue.main)
         .sink { [weak self] sessions, connection in
             guard let connection else { return }

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/SettingsConnectedAppPermissionsController.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/SettingsConnectedAppPermissionsController.swift
@@ -18,8 +18,8 @@ class SettingsConnectedAppPermissionsController: UIViewController {
     }
     
     enum TableItem: Hashable {
-        case mainInfo(AppConnection, lastSession: AppSession?)
-        case permission(AppPermissionGroup, AppConnection)
+        case mainInfo(RemoteAppConnection, lastSession: RemoteAppSession?)
+        case permission(AppPermissionGroup, RemoteAppConnection)
         case reset
         
         var cellId: String {
@@ -33,7 +33,7 @@ class SettingsConnectedAppPermissionsController: UIViewController {
     
     var cancellables: Set<AnyCancellable> = []
     
-    @Published var items: [AppConnection] = []
+    @Published var items: [RemoteAppConnection] = []
     
     let dataSource: UITableViewDiffableDataSource<TableSections, TableItem>
     
@@ -104,7 +104,7 @@ class SettingsConnectedAppPermissionsController: UIViewController {
     
     func refresh() {
         Publishers.CombineLatest3(
-            RemoteSignerManager.instance.sessionRepo.observeSessionsByClientPubKey(clientPubKey: connectionID).toPublisher().map { $0 as [AppSession] },
+            RemoteSignerManager.instance.sessionRepo.observeSessionsByClientPubKey(clientPubKey: connectionID).toPublisher().map { $0 as [RemoteAppSession] },
             RemoteSignerManager.instance.connectionRepo.observeConnection(clientPubKey: connectionID).toPublisher(),
             RemoteSignerManager.instance.permissionRepo.observePermissions(clientPubKey: connectionID).toPublisher()
         )
@@ -154,7 +154,7 @@ extension SettingsConnectedAppPermissionsController: UITableViewDelegate {
 }
 
 extension SettingsConnectedAppPermissionsController: RemoteSignerPermissionEditCellDelegate {
-    func remoteSignerPermissionEditCell(_ cell: RemoteSignerPermissionEditCell, didSelect action: PrimalShared.PermissionAction) {
+    func remoteSignerPermissionEditCell(_ cell: RemoteSignerPermissionEditCell, didSelect action: PrimalShared.AppPermissionAction) {
         var snapshot = dataSource.snapshot()
         var permissions = snapshot.itemIdentifiers(inSection: .permissions)
         guard

--- a/Primal/Scenes/Settings/SubControllers/RemoteSigning/SettingsRemoteSignerController.swift
+++ b/Primal/Scenes/Settings/SubControllers/RemoteSigning/SettingsRemoteSignerController.swift
@@ -9,19 +9,19 @@ import Combine
 import UIKit
 import PrimalShared
 
-extension AppConnection: @retroactive Identifiable {
+extension RemoteAppConnection: @retroactive Identifiable {
     
 }
 
 class SettingsRemoteSignerController: UIViewController, Themeable {
     
     enum TableItem: Hashable {
-        case connection(AppConnection, ParsedUser)
+        case connection(RemoteAppConnection, ParsedUser)
     }
     
     var cancellables: Set<AnyCancellable> = []
     
-    @Published var items: [AppConnection] = []
+    @Published var items: [RemoteAppConnection] = []
     
     let dataSource: UITableViewDiffableDataSource<SingleSection, TableItem>
     
@@ -85,13 +85,13 @@ extension SettingsRemoteSignerController: UITableViewDelegate {
     }
 }
 
-extension AppConnection {
+extension RemoteAppConnection {
     func defaultImage(size: CGFloat, color: UIColor = .foreground3, background: UIColor = .foreground.withAlphaComponent(0.1)) -> UIImage? {
         return UIImage.create(letter: String(self.name?.first ?? "?"), size: size, color: color, backgroundColor: background)
     }
 }
 
-extension AppSession {
+extension RemoteAppSession {
     func defaultImage(size: CGFloat, color: UIColor = .foreground3, background: UIColor = .foreground.withAlphaComponent(0.1)) -> UIImage? {
         return UIImage.create(letter: String(self.name?.first ?? "?"), size: size, color: color, backgroundColor: background)
     }

--- a/Primal/State/Managers/RemoteSigning/RemoteSignerManager.swift
+++ b/Primal/State/Managers/RemoteSigning/RemoteSignerManager.swift
@@ -23,9 +23,9 @@ class RemoteSignerManager {
     
     var cancellables: Set<AnyCancellable> = []
     
-    @Published var activeSessions: [AppSession] = []
+    @Published var activeSessions: [RemoteAppSession] = []
     
-    @Published var activeConnections: [AppConnection] = []
+    @Published var activeConnections: [RemoteAppConnection] = []
     
     var permissionsMap: [String: String] = [:]
     
@@ -137,7 +137,13 @@ class RemoteSignerManager {
         
         Task {
             do {
-                let result = try await signerConnectionInit.initialize(signerPubKey: signerPubkey, userPubKey: userPubKey, connectionUrl: url, trustLevel: trustLevel).getOrThrow()
+                let result = try await signerConnectionInit.initialize(
+                    signerPubKey: signerPubkey,
+                    userPubKey: userPubKey,
+                    connectionUrl: url,
+                    trustLevel: trustLevel,
+                    nwcConnectionString: nil,
+                ).getOrThrow()
             } catch let error {
                 print("REMOTE SIGNER error: \(error)")
             }
@@ -148,7 +154,7 @@ class RemoteSignerManager {
         endSessions(activeSessions)
     }
     
-    func endSessions(_ sessions: [AppSession]) {
+    func endSessions(_ sessions: [RemoteAppSession]) {
         Task {
             try? await sessionRepo.endSessions(sessionIds: sessions.map { $0.sessionId })
         }


### PR DESCRIPTION
- `AppConnection` renamed to `RemoteAppConnection`
- `AppSession` renamed to `RemoteAppSessions`
- `PermissionAction` renamed to `AppPermissionAction`