### PR TITLE
Add translate action to note menu

### DIFF
--- a/Primal/Common/Views/Feed/PostCell/Helpers/PostCellEvent.swift
+++ b/Primal/Common/Views/Feed/PostCell/Helpers/PostCellEvent.swift
@@ -34,6 +34,7 @@ enum PostCellEvent {
     
     case share
     case shareAsImage
+    case translate
     case copy(NoteCopiableProperty)
     case report
     case muteUser

--- a/Primal/Common/Views/Feed/PostCell/PostCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/PostCell.swift
@@ -229,6 +229,7 @@ class PostCell: UITableViewCell {
         
         let actionsData: [(String, String, PostCellEvent, UIMenuElement.Attributes)] = [
             ("Share Note", "MenuShare", .share, []),
+            ("Translate Note", "MenuCopyText", .translate, []),
             ("Copy Note Link", "MenuCopyLink", .copy(.link), []),
             postInfo.isBookmarked ? unbookmarkAction : bookmarkAction,
             ("Copy Note Text", "MenuCopyText", .copy(.content), []),

--- a/Primal/Scenes/Feed/NoteViewController.swift
+++ b/Primal/Scenes/Feed/NoteViewController.swift
@@ -449,6 +449,8 @@ class NoteViewController: UIViewController, UITableViewDelegate, Themeable, Wall
         case .share:
             let activityViewController = UIActivityViewController(activityItems: [post.webURL()], applicationActivities: nil)
             present(activityViewController, animated: true, completion: nil)
+        case .translate:
+            openTranslation(for: post)
         case .shareAsImage:
             guard
                 let cell,
@@ -518,6 +520,25 @@ class NoteViewController: UIViewController, UITableViewDelegate, Themeable, Wall
     
     func showToast(_ message: String) {
         mainTabBarController?.showToast(message)
+    }
+
+    func openTranslation(for post: ParsedContent) {
+        let text = post.post.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "translate.google.com"
+        components.queryItems = [
+            URLQueryItem(name: "sl", value: "auto"),
+            URLQueryItem(name: "tl", value: Locale.preferredLanguages.first?.split(separator: "-").first.map(String.init) ?? Locale.current.languageCode ?? "en"),
+            URLQueryItem(name: "text", value: text),
+            URLQueryItem(name: "op", value: "translate")
+        ]
+
+        guard let url = components.url else { return }
+
+        present(SFSafariViewController(url: url), animated: true)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a Translate Note item to the post overflow menu
- open Google Translate in an in-app Safari view with source auto-detection and the device preferred language as target
- keep the change scoped to the existing menu/event flow

Refs #206

## Test
- xcrun swiftc -parse Primal/Common/Views/Feed/PostCell/Helpers/PostCellEvent.swift
- xcrun swiftc -parse Primal/Common/Views/Feed/PostCell/PostCell.swift
- xcrun swiftc -parse Primal/Scenes/Feed/NoteViewController.swift

Note: xcodebuild -list -project Primal.xcodeproj stalled locally while resolving project state, so I could not run a full app build in this checkout.