### PR TITLE
Add inline note translation

### DIFF
--- a/Primal.xcodeproj/project.pbxproj
+++ b/Primal.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		933B85772A9F6EE300C48FF6 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933B85762A9F6EE300C48FF6 /* Utils.swift */; };
 		933DBDBD2A1145A1008DCF1F /* StringProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933DBDBC2A1145A1008DCF1F /* StringProtocol.swift */; };
 		933DBDBF2A11FF87008DCF1F /* ParsedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933DBDBE2A11FF87008DCF1F /* ParsedContent.swift */; };
+		C0D1E2060000000000000001 /* NoteTranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1E2060000000000000002 /* NoteTranslationService.swift */; };
+		C0D1E2060000000000000003 /* NoteTranslationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1E2060000000000000004 /* NoteTranslationView.swift */; };
 		9344DB312A1D28EB00C9F281 /* NostrKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9344DB302A1D28EB00C9F281 /* NostrKind.swift */; };
 		9363DE712A30DD9E0060F4BD /* DeeplinkHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363DE702A30DD9E0060F4BD /* DeeplinkHandlerProtocol.swift */; };
 		9363DE732A30DDB90060F4BD /* DeeplinkHandlerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363DE722A30DDB90060F4BD /* DeeplinkHandlerCoordinator.swift */; };
@@ -841,6 +843,8 @@
 		933B85762A9F6EE300C48FF6 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		933DBDBC2A1145A1008DCF1F /* StringProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocol.swift; sourceTree = "<group>"; };
 		933DBDBE2A11FF87008DCF1F /* ParsedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsedContent.swift; sourceTree = "<group>"; };
+		C0D1E2060000000000000002 /* NoteTranslationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTranslationService.swift; sourceTree = "<group>"; };
+		C0D1E2060000000000000004 /* NoteTranslationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTranslationView.swift; sourceTree = "<group>"; };
 		9344DB302A1D28EB00C9F281 /* NostrKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrKind.swift; sourceTree = "<group>"; };
 		9363DE702A30DD9E0060F4BD /* DeeplinkHandlerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandlerProtocol.swift; sourceTree = "<group>"; };
 		9363DE722A30DDB90060F4BD /* DeeplinkHandlerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandlerCoordinator.swift; sourceTree = "<group>"; };
@@ -2375,6 +2379,8 @@
 				9E9D46F72A0A72B900D4837B /* PostCell.swift */,
 				B99E03882BF7B10C006CCECB /* PostFeedCell.swift */,
 				9E9D46F42A0A717400D4837B /* ThreadCell.swift */,
+				C0D1E2060000000000000002 /* NoteTranslationService.swift */,
+				C0D1E2060000000000000004 /* NoteTranslationView.swift */,
 			);
 			path = PostCell;
 			sourceTree = "<group>";
@@ -4320,6 +4326,8 @@
 				B9DAA4582D4A61D400B00B82 /* NWCScheme.swift in Sources */,
 				B914CD6B2AA20DC400CD0BD1 /* MutedUserCell.swift in Sources */,
 				933DBDBF2A11FF87008DCF1F /* ParsedContent.swift in Sources */,
+				C0D1E2060000000000000001 /* NoteTranslationService.swift in Sources */,
+				C0D1E2060000000000000003 /* NoteTranslationView.swift in Sources */,
 				B9E67EAA2D09D8FA006BB397 /* ThreadElementUserCell.swift in Sources */,
 				B91E56E82CB9843A00C14809 /* AdvancedSearchMenuItemView.swift in Sources */,
 				B9E67E7D2D075E35006BB397 /* FeedElementUserCell.swift in Sources */,

--- a/Primal/Common/Views/Feed/PostCell/NoteTranslationService.swift
+++ b/Primal/Common/Views/Feed/PostCell/NoteTranslationService.swift
@@ -1,0 +1,243 @@
+//
+//  NoteTranslationService.swift
+//  Primal
+//
+
+import Foundation
+
+struct NoteTranslationSettings {
+    private static let defaults = UserDefaults.standard
+
+    static var isEnabled: Bool {
+        get {
+            guard defaults.object(forKey: "noteTranslationEnabled") != nil else { return true }
+            return defaults.bool(forKey: "noteTranslationEnabled")
+        }
+        set { defaults.set(newValue, forKey: "noteTranslationEnabled") }
+    }
+
+    static var endpointURL: URL {
+        get {
+            if let string = defaults.string(forKey: "noteTranslationEndpointURL"), let url = URL(string: string) {
+                return url
+            }
+            return URL(string: "https://libretranslate.com/translate")!
+        }
+        set { defaults.set(newValue.absoluteString, forKey: "noteTranslationEndpointURL") }
+    }
+
+    static var apiKey: String {
+        get { defaults.string(forKey: "noteTranslationAPIKey") ?? "" }
+        set { defaults.set(newValue, forKey: "noteTranslationAPIKey") }
+    }
+
+    static var targetLanguage: String {
+        get {
+            if let language = defaults.string(forKey: "noteTranslationTargetLanguage"), !language.isEmpty {
+                return language
+            }
+            return Locale.preferredLanguages.first?
+                .split(separator: "-")
+                .first
+                .map(String.init) ?? "en"
+        }
+        set { defaults.set(newValue, forKey: "noteTranslationTargetLanguage") }
+    }
+}
+
+final class NoteTranslationService {
+    struct TranslationResult {
+        let translatedText: String
+        let detectedLanguage: String?
+    }
+
+    enum TranslationError: Error {
+        case disabled
+        case emptyText
+        case badResponse
+        case noTranslation
+    }
+
+    static let shared = NoteTranslationService()
+
+    private let cache = NSCache<NSString, CachedTranslation>()
+    private let minimumTextLength = 12
+
+    private init() {}
+
+    func shouldOfferTranslation(for text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard NoteTranslationSettings.isEnabled, trimmed.count >= minimumTextLength else { return false }
+        return trimmed.rangeOfCharacter(from: .letters) != nil
+    }
+
+    func translate(_ text: String, completion: @escaping (Result<TranslationResult, Error>) -> Void) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard NoteTranslationSettings.isEnabled else {
+            completion(.failure(TranslationError.disabled))
+            return
+        }
+
+        guard shouldOfferTranslation(for: trimmed) else {
+            completion(.failure(TranslationError.emptyText))
+            return
+        }
+
+        let targetLanguage = NoteTranslationSettings.targetLanguage
+        let cacheKey = cacheKey(for: trimmed, targetLanguage: targetLanguage)
+
+        if let cached = cache.object(forKey: cacheKey as NSString) {
+            completion(.success(.init(translatedText: cached.translatedText, detectedLanguage: cached.detectedLanguage)))
+            return
+        }
+
+        let protectedText = protectEntities(in: trimmed)
+        var request = URLRequest(url: NoteTranslationSettings.endpointURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        var payload: [String: Any] = [
+            "q": protectedText.text,
+            "source": "auto",
+            "target": targetLanguage,
+            "format": "text"
+        ]
+
+        let apiKey = NoteTranslationSettings.apiKey
+        if !apiKey.isEmpty {
+            payload["api_key"] = apiKey
+        }
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else { return }
+
+            if let error {
+                DispatchQueue.main.async { completion(.failure(error)) }
+                return
+            }
+
+            guard
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let data
+            else {
+                DispatchQueue.main.async { completion(.failure(TranslationError.badResponse)) }
+                return
+            }
+
+            do {
+                let decoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                guard let translated = decoded?["translatedText"] as? String else {
+                    DispatchQueue.main.async { completion(.failure(TranslationError.noTranslation)) }
+                    return
+                }
+
+                let result = TranslationResult(
+                    translatedText: self.restoreEntities(in: translated, replacements: protectedText.replacements),
+                    detectedLanguage: self.detectedLanguage(from: decoded?["detectedLanguage"])
+                )
+
+                self.cache.setObject(
+                    CachedTranslation(translatedText: result.translatedText, detectedLanguage: result.detectedLanguage),
+                    forKey: cacheKey as NSString
+                )
+
+                DispatchQueue.main.async { completion(.success(result)) }
+            } catch {
+                DispatchQueue.main.async { completion(.failure(error)) }
+            }
+        }.resume()
+    }
+}
+
+private extension NoteTranslationService {
+    struct ProtectedText {
+        let text: String
+        let replacements: [String: String]
+    }
+
+    struct ProtectedEntity {
+        let range: NSRange
+        let value: String
+    }
+
+    func cacheKey(for text: String, targetLanguage: String) -> String {
+        "\(targetLanguage)|\(NoteTranslationSettings.endpointURL.absoluteString)|\(text)"
+            .data(using: .utf8)?
+            .hash256() ?? UUID().uuidString
+    }
+
+    func protectEntities(in text: String) -> ProtectedText {
+        let nsText = text as NSString
+        let patterns = [
+            #"https?://[^\s]+"#,
+            #"nostr:[^\s]+"#,
+            #"\b(?:npub1|nprofile1|note1|nevent1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]+"#,
+            #"\blnbc[0-9a-z]+"#,
+            #"\bbc1[0-9a-z]+"#,
+            #"(?<!\w)#[\p{L}\p{N}_]+"#,
+            #"(?<!\w)@[\p{L}\p{N}_.-]+"#
+        ]
+
+        let matches = patterns.flatMap { pattern -> [ProtectedEntity] in
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return [] }
+            return regex.matches(in: text, range: NSRange(location: 0, length: nsText.length)).map {
+                ProtectedEntity(range: $0.range, value: nsText.substring(with: $0.range))
+            }
+        }
+        .sorted { $0.range.location < $1.range.location }
+
+        var selected: [ProtectedEntity] = []
+        for match in matches {
+            guard let previous = selected.last else {
+                selected.append(match)
+                continue
+            }
+            if match.range.location >= previous.range.location + previous.range.length {
+                selected.append(match)
+            }
+        }
+
+        var protectedText = text
+        var replacements: [String: String] = [:]
+
+        for (index, entity) in selected.reversed().enumerated() {
+            let token = "PRIMALENTITY_\(index)_TOKEN"
+            replacements[token] = entity.value
+            protectedText = (protectedText as NSString).replacingCharacters(in: entity.range, with: token)
+        }
+
+        return ProtectedText(text: protectedText, replacements: replacements)
+    }
+
+    func restoreEntities(in text: String, replacements: [String: String]) -> String {
+        replacements.reduce(text) { partial, replacement in
+            partial.replacingOccurrences(of: replacement.key, with: replacement.value)
+        }
+    }
+
+    func detectedLanguage(from value: Any?) -> String? {
+        if let string = value as? String {
+            return string
+        }
+
+        if let dictionary = value as? [String: Any] {
+            return dictionary["language"] as? String
+        }
+
+        return nil
+    }
+}
+
+private final class CachedTranslation {
+    let translatedText: String
+    let detectedLanguage: String?
+
+    init(translatedText: String, detectedLanguage: String?) {
+        self.translatedText = translatedText
+        self.detectedLanguage = detectedLanguage
+    }
+}

--- a/Primal/Common/Views/Feed/PostCell/NoteTranslationView.swift
+++ b/Primal/Common/Views/Feed/PostCell/NoteTranslationView.swift
@@ -1,0 +1,121 @@
+//
+//  NoteTranslationView.swift
+//  Primal
+//
+
+import UIKit
+
+final class NoteTranslationView: UIStackView {
+    private let translateButton = UIButton(type: .system)
+    private let translatedLabel = UILabel()
+    private let sourceLabel = UILabel()
+
+    private var currentText = ""
+    private var currentRequestID = UUID()
+    private var translationResult: NoteTranslationService.TranslationResult?
+    private var isShowingTranslation = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with text: String) {
+        currentText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        currentRequestID = UUID()
+        translationResult = nil
+        isShowingTranslation = false
+
+        translatedLabel.text = nil
+        sourceLabel.text = nil
+        translatedLabel.isHidden = true
+        sourceLabel.isHidden = true
+
+        isHidden = !NoteTranslationService.shared.shouldOfferTranslation(for: currentText)
+        translateButton.isEnabled = true
+        translateButton.setTitle("Translate", for: .normal)
+    }
+}
+
+private extension NoteTranslationView {
+    func setup() {
+        axis = .vertical
+        alignment = .fill
+        spacing = 5
+        isHidden = true
+
+        translateButton.contentHorizontalAlignment = .leading
+        translateButton.titleLabel?.font = .appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular)
+        translateButton.tintColor = .accent2
+        translateButton.setContentCompressionResistancePriority(.required, for: .vertical)
+        translateButton.addTarget(self, action: #selector(translateTapped), for: .touchUpInside)
+
+        translatedLabel.numberOfLines = 0
+        translatedLabel.font = .appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular)
+        translatedLabel.textColor = .foreground
+        translatedLabel.isHidden = true
+
+        sourceLabel.numberOfLines = 1
+        sourceLabel.font = .appFont(withSize: 12, weight: .regular)
+        sourceLabel.textColor = .foreground3
+        sourceLabel.isHidden = true
+
+        addArrangedSubview(translateButton)
+        addArrangedSubview(translatedLabel)
+        addArrangedSubview(sourceLabel)
+    }
+
+    @objc func translateTapped() {
+        if translationResult != nil {
+            isShowingTranslation.toggle()
+            updateVisibleTranslation()
+            return
+        }
+
+        let requestID = UUID()
+        currentRequestID = requestID
+        translateButton.isEnabled = false
+        translateButton.setTitle("Translating...", for: .normal)
+
+        NoteTranslationService.shared.translate(currentText) { [weak self] result in
+            guard let self, self.currentRequestID == requestID else { return }
+
+            self.translateButton.isEnabled = true
+
+            switch result {
+            case .success(let translation):
+                self.translationResult = translation
+                self.isShowingTranslation = true
+                self.updateVisibleTranslation()
+            case .failure:
+                self.translationResult = nil
+                self.isShowingTranslation = false
+                self.translatedLabel.text = "Translation unavailable."
+                self.translatedLabel.isHidden = false
+                self.sourceLabel.isHidden = true
+                self.translateButton.setTitle("Retry Translate", for: .normal)
+            }
+        }
+    }
+
+    func updateVisibleTranslation() {
+        guard let translationResult else { return }
+
+        translatedLabel.text = isShowingTranslation ? translationResult.translatedText : nil
+        translatedLabel.isHidden = !isShowingTranslation
+
+        if isShowingTranslation, let detectedLanguage = translationResult.detectedLanguage, !detectedLanguage.isEmpty {
+            sourceLabel.text = "Translated from \(detectedLanguage.uppercased())"
+            sourceLabel.isHidden = false
+        } else {
+            sourceLabel.text = nil
+            sourceLabel.isHidden = true
+        }
+
+        translateButton.setTitle(isShowingTranslation ? "Hide translation" : "Show translation", for: .normal)
+    }
+}

--- a/Primal/Common/Views/Feed/PostCell/PostCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/PostCell.swift
@@ -33,6 +33,7 @@ class PostCell: UITableViewCell {
     let nipLabel = UILabel()
     let replyingToView = ReplyingToView()
     let mainLabel = NantesLabel()
+    let translationView = NoteTranslationView()
     let invoiceView = LightningInvoiceView()
     let mainImages = ImageGalleryView()
     let articleView = ArticleFeedView()
@@ -207,6 +208,7 @@ class PostCell: UITableViewCell {
         }
         
         mainLabel.attributedText = useShortText ? content.attributedTextShort : content.attributedText
+        translationView.configure(with: content.text)
         mainImages.resources = content.mediaResources
         mainImages.thumbnails = content.videoThumbnails
         

--- a/Primal/Common/Views/Feed/PostCell/PostFeedCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/PostFeedCell.swift
@@ -10,7 +10,7 @@ import Kingfisher
 
 class PostFeedCell: PostCell {
     lazy var seeMoreLabel = UILabel()
-    lazy var textStack = UIStackView(arrangedSubviews: [mainLabel, seeMoreLabel])
+    lazy var textStack = UIStackView(arrangedSubviews: [mainLabel, seeMoreLabel, translationView])
     let threeDotsSpacer = SpacerView(width: 20)
     lazy var mainStack = UIStackView(arrangedSubviews: [repostIndicator])
     

--- a/Primal/Common/Views/Feed/PostCell/ThreadCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/ThreadCell.swift
@@ -150,7 +150,7 @@ final class PostThreadCell: ThreadCell {
         
         let actionButtonStandin = UIView()
         let contentStack = UIStackView(arrangedSubviews: [
-            mainLabel, invoiceView, articleView, mainImages, linkPresentation, postPreview, zapPreview, infoView, smallGallery, SpacerView(height: 0), actionButtonStandin
+            mainLabel, translationView, invoiceView, articleView, mainImages, linkPresentation, postPreview, zapPreview, infoView, smallGallery, SpacerView(height: 0), actionButtonStandin
         ])
         
         let horizontalContentStack = UIStackView(arrangedSubviews: [contentSpacer, contentStack])


### PR DESCRIPTION
## Summary

Refs PrimalHQ/primal-ios-app#206.

Adds inline note translation for feed and thread cells:
- shows a `Translate` control directly below eligible note text
- translates through a LibreTranslate-compatible endpoint
- uses the device preferred language as the default target language
- supports `UserDefaults` configuration for enabled state, endpoint URL, API key, and target language
- caches translations in memory for the current app session
- protects URLs, nostr references, Lightning invoices, Bitcoin addresses, hashtags, and handles from being modified by the translation provider
- handles reusable cells safely by ignoring stale translation callbacks

## Notes

The default endpoint is `https://libretranslate.com/translate`; self-hosters or later Settings UI can set `noteTranslationEndpointURL`, `noteTranslationAPIKey`, `noteTranslationTargetLanguage`, and `noteTranslationEnabled`.

This keeps the implementation client-side and avoids adding backend cost for Primal.

## Verification

- `git diff --check`
- Could not run `xcodebuild` or `swift` in this Windows environment; both tools are unavailable here.
