### PR TITLE
feat: inline note translation with LibreTranslate (#208)

### DIFF
--- a/Primal.xcodeproj/project.pbxproj
+++ b/Primal.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		024790235F8243AC95A947C7 /* PollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254BECF85EE9411B88FDCEFA /* PollView.swift */; };
+		0A9335F336F9460F6AD26BEE /* NoteTranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1362A58B49FDEA45A394E8D2 /* NoteTranslationService.swift */; };
 		2D7F552B70900BC23221F4AC /* PollVoteOptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1B50E71AC4CB3BACD02E0A /* PollVoteOptionCell.swift */; };
 		2F98EB1DCC624734794395F1 /* PollVoteUserCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251E11AFC9FB66D804B5217F /* PollVoteUserCell.swift */; };
 		37F34936B75F413BAC729EB5 /* FeedElementPollCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11014EF06E484DF7AE794F7D /* FeedElementPollCell.swift */; };
@@ -752,8 +753,10 @@
 		C7F8A2B3D4E5061798A3B1C2 /* PrimalPremiumLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F8A2B3D4E5061798A3B1C3 /* PrimalPremiumLogoView.swift */; };
 		D2B3C4E5F6A7089012345679 /* CacheBreakdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3C4E5F6A7089012345678 /* CacheBreakdownView.swift */; };
 		D5A4266E6F84FB8044839C0E /* PollVoteDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBBAA6B683A9D0CB02B7060 /* PollVoteDetailsCell.swift */; };
+		D6285FE9715E496830EDCFD5 /* NoteTranslationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7AA648627E2689C746300DA /* NoteTranslationView.swift */; };
 		E365D8456ACE78BF9DE4C077 /* OldWalletDetectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5764AD3FE766D500CBC6420 /* OldWalletDetectedView.swift */; };
 		ED696C5B32C51E1E05C1EADD /* LiveVideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BCEEB23F4CCE0243097494 /* LiveVideoPlayer.swift */; };
+		F2C47684F44B346A5CB05112 /* SettingsTranslationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B8542D7841C091345F6AAF /* SettingsTranslationViewController.swift */; };
 		F8E7A8239A9F7E466C01EBF5 /* FeedVideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D490ED6A30BA8537BEBDF /* FeedVideoPlayer.swift */; };
 /* End PBXBuildFile section */
 
@@ -823,9 +826,11 @@
 
 /* Begin PBXFileReference section */
 		11014EF06E484DF7AE794F7D /* FeedElementPollCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedElementPollCell.swift; sourceTree = "<group>"; };
+		1362A58B49FDEA45A394E8D2 /* NoteTranslationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoteTranslationService.swift; path = Primal/Common/Views/Feed/PostCell/NoteTranslationService.swift; sourceTree = "<group>"; };
 		251E11AFC9FB66D804B5217F /* PollVoteUserCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollVoteUserCell.swift; sourceTree = "<group>"; };
 		254BECF85EE9411B88FDCEFA /* PollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollView.swift; sourceTree = "<group>"; };
 		32167054FC4146F3845A370A /* ThreadElementPollCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadElementPollCell.swift; sourceTree = "<group>"; };
+		34B8542D7841C091345F6AAF /* SettingsTranslationViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsTranslationViewController.swift; path = Primal/Scenes/Settings/SubControllers/SettingsTranslationViewController.swift; sourceTree = "<group>"; };
 		58BCEEB23F4CCE0243097494 /* LiveVideoPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveVideoPlayer.swift; sourceTree = "<group>"; };
 		661FE298A909D88F0B34B14F /* PollVotesDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollVotesDatasource.swift; sourceTree = "<group>"; };
 		731729354B231F6AE303270F /* PollVoteTitleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollVoteTitleCell.swift; sourceTree = "<group>"; };
@@ -1590,25 +1595,26 @@
 		D2B3C4E5F6A7089012345678 /* CacheBreakdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheBreakdownView.swift; sourceTree = "<group>"; };
 		EC1B50E71AC4CB3BACD02E0A /* PollVoteOptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollVoteOptionCell.swift; sourceTree = "<group>"; };
 		F2BF0F83E0F616FCB6C4AB48 /* PollResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollResultsViewController.swift; sourceTree = "<group>"; };
+		F7AA648627E2689C746300DA /* NoteTranslationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoteTranslationView.swift; path = Primal/Common/Views/Feed/PostCell/NoteTranslationView.swift; sourceTree = "<group>"; };
 		FDBBAA6B683A9D0CB02B7060 /* PollVoteDetailsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollVoteDetailsCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		B9658AF62D9FF9460037E5DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		B9658AF62D9FF9460037E5DB /* Exceptions for "PrimalNotifications" folder in "PrimalNotifications" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = B9658AEB2D9FF9460037E5DB /* PrimalNotifications */;
 		};
-		B9DFA0B12D7EFBC9002C6F34 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		B9DFA0B12D7EFBC9002C6F34 /* Exceptions for "primalShare" folder in "primalShare" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = B9DFA0A22D7EFBC9002C6F34 /* primalShare */;
 		};
-		B9E0E64C2EF08D0800F48B2A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		B9E0E64C2EF08D0800F48B2A /* Exceptions for "RemoteSignerWidget" folder in "RemoteSignerWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -1616,7 +1622,7 @@
 			);
 			target = B9E0E6352EF08D0500F48B2A /* RemoteSignerWidgetExtension */;
 		};
-		B9E0E6552EF1F58200F48B2A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		B9E0E6552EF1F58200F48B2A /* Exceptions for "RemoteSignerWidget" folder in "Primal" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				AppIntent.swift,
@@ -1629,9 +1635,43 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		B9658AED2D9FF9460037E5DB /* PrimalNotifications */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B9658AF62D9FF9460037E5DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = PrimalNotifications; sourceTree = "<group>"; };
-		B9DFA0A42D7EFBC9002C6F34 /* primalShare */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B9DFA0B12D7EFBC9002C6F34 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = primalShare; sourceTree = "<group>"; };
-		B9E0E63B2EF08D0600F48B2A /* RemoteSignerWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B9E0E6552EF1F58200F48B2A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, B9E0E64C2EF08D0800F48B2A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = RemoteSignerWidget; sourceTree = "<group>"; };
+		B9658AED2D9FF9460037E5DB /* PrimalNotifications */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				B9658AF62D9FF9460037E5DB /* Exceptions for "PrimalNotifications" folder in "PrimalNotifications" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = PrimalNotifications;
+			sourceTree = "<group>";
+		};
+		B9DFA0A42D7EFBC9002C6F34 /* primalShare */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				B9DFA0B12D7EFBC9002C6F34 /* Exceptions for "primalShare" folder in "primalShare" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = primalShare;
+			sourceTree = "<group>";
+		};
+		B9E0E63B2EF08D0600F48B2A /* RemoteSignerWidget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				B9E0E6552EF1F58200F48B2A /* Exceptions for "RemoteSignerWidget" folder in "Primal" target */,
+				B9E0E64C2EF08D0800F48B2A /* Exceptions for "RemoteSignerWidget" folder in "RemoteSignerWidgetExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = RemoteSignerWidget;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1702,6 +1742,38 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		53674D879DBAC96BB352F006 /* SubControllers */ = {
+			isa = PBXGroup;
+			children = (
+				34B8542D7841C091345F6AAF /* SettingsTranslationViewController.swift */,
+			);
+			name = SubControllers;
+			sourceTree = "<group>";
+		};
+		736A0474675AA9E307E170F8 /* Feed */ = {
+			isa = PBXGroup;
+			children = (
+				B8890F1FEC023ADA88E83489 /* PostCell */,
+			);
+			name = Feed;
+			sourceTree = "<group>";
+		};
+		7DA168AC14D2020296490BC0 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				736A0474675AA9E307E170F8 /* Feed */,
+			);
+			name = Views;
+			sourceTree = "<group>";
+		};
+		874C975F831BE3324D50128B /* Scenes */ = {
+			isa = PBXGroup;
+			children = (
+				96D5C5492851AC8EFED118BF /* Settings */,
+			);
+			name = Scenes;
+			sourceTree = "<group>";
+		};
 		933DBDA82A1124F7008DCF1F /* Notes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1771,6 +1843,7 @@
 				B9E0E63B2EF08D0600F48B2A /* RemoteSignerWidget */,
 				939330F329A3E36F003954C2 /* Products */,
 				933DBDB12A1126CE008DCF1F /* Frameworks */,
+				9BB6494955BD9DBC6DEE59FF /* Primal */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2076,6 +2149,23 @@
 				B98DD8C72C5C108700E8369A /* Article.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		96D5C5492851AC8EFED118BF /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				53674D879DBAC96BB352F006 /* SubControllers */,
+			);
+			name = Settings;
+			sourceTree = "<group>";
+		};
+		9BB6494955BD9DBC6DEE59FF /* Primal */ = {
+			isa = PBXGroup;
+			children = (
+				E5750C5A47D5F1D308A23277 /* Common */,
+				874C975F831BE3324D50128B /* Scenes */,
+			);
+			name = Primal;
 			sourceTree = "<group>";
 		};
 		9E0DEAF029FD301D00145E08 /* Animations */ = {
@@ -2535,6 +2625,15 @@
 				9EF4BFC32A8BE9C5003396AA /* IceWave.swift */,
 			);
 			path = Themes;
+			sourceTree = "<group>";
+		};
+		B8890F1FEC023ADA88E83489 /* PostCell */ = {
+			isa = PBXGroup;
+			children = (
+				1362A58B49FDEA45A394E8D2 /* NoteTranslationService.swift */,
+				F7AA648627E2689C746300DA /* NoteTranslationView.swift */,
+			);
+			name = PostCell;
 			sourceTree = "<group>";
 		};
 		B90032832BD0180300ADD2E5 /* SocketRequests */ = {
@@ -3752,6 +3851,14 @@
 			path = Scheme;
 			sourceTree = "<group>";
 		};
+		E5750C5A47D5F1D308A23277 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				7DA168AC14D2020296490BC0 /* Views */,
+			);
+			name = Common;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -3874,8 +3981,6 @@
 				B9DFA0A42D7EFBC9002C6F34 /* primalShare */,
 			);
 			name = primalShare;
-			packageProductDependencies = (
-			);
 			productName = primalShare;
 			productReference = B9DFA0A32D7EFBC9002C6F34 /* primalShare.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -3896,8 +4001,6 @@
 				B9E0E63B2EF08D0600F48B2A /* RemoteSignerWidget */,
 			);
 			name = RemoteSignerWidgetExtension;
-			packageProductDependencies = (
-			);
 			productName = RemoteSignerWidgetExtension;
 			productReference = B9E0E6362EF08D0500F48B2A /* RemoteSignerWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -4740,6 +4843,9 @@
 				B9DF0CB22C25AD78009ADC7B /* LargeZapGalleryView.swift in Sources */,
 				B9318F602B6048FE0044B6AA /* SettingsEditZapController.swift in Sources */,
 				B9DAA45A2D4A634500B00B82 /* SettingsExternalNwcController.swift in Sources */,
+				0A9335F336F9460F6AD26BEE /* NoteTranslationService.swift in Sources */,
+				D6285FE9715E496830EDCFD5 /* NoteTranslationView.swift in Sources */,
+				F2C47684F44B346A5CB05112 /* SettingsTranslationViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Primal/Common/Views/Feed/PostCell/NoteTranslationService.swift
+++ b/Primal/Common/Views/Feed/PostCell/NoteTranslationService.swift
@@ -1,0 +1,280 @@
+//
+//  NoteTranslationService.swift
+//  Primal
+//
+//  Created for Primal iOS app — inline note translation via LibreTranslate
+//
+
+import Foundation
+
+// MARK: - Translation Settings (UserDefaults-backed)
+
+extension String {
+    static let noteTranslationEnabledKey = "noteTranslationEnabled"
+    static let noteTranslationEndpointURLKey = "noteTranslationEndpointURL"
+    static let noteTranslationAPIKeyKey = "noteTranslationAPIKey"
+    static let noteTranslationTargetLanguageKey = "noteTranslationTargetLanguage"
+}
+
+struct NoteTranslationSettings {
+    static var isEnabled: Bool {
+        get {
+            guard UserDefaults.standard.object(forKey: .noteTranslationEnabledKey) != nil else { return true }
+            return UserDefaults.standard.bool(forKey: .noteTranslationEnabledKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: .noteTranslationEnabledKey) }
+    }
+
+    static var endpointURL: URL {
+        get {
+            if let string = UserDefaults.standard.string(forKey: .noteTranslationEndpointURLKey),
+               let url = URL(string: string) {
+                return url
+            }
+            return URL(string: "https://libretranslate.com/translate")!
+        }
+        set { UserDefaults.standard.set(newValue.absoluteString, forKey: .noteTranslationEndpointURLKey) }
+    }
+
+    static var apiKey: String {
+        get { UserDefaults.standard.string(forKey: .noteTranslationAPIKeyKey) ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: .noteTranslationAPIKeyKey) }
+    }
+
+    static var targetLanguage: String {
+        get {
+            if let language = UserDefaults.standard.string(forKey: .noteTranslationTargetLanguageKey),
+               !language.isEmpty {
+                return language
+            }
+            return Locale.preferredLanguages.first?
+                .split(separator: "-")
+                .first
+                .map(String.init) ?? "en"
+        }
+        set { UserDefaults.standard.set(newValue, forKey: .noteTranslationTargetLanguageKey) }
+    }
+}
+
+// MARK: - Translation Service
+
+final class NoteTranslationService {
+    struct TranslationResult {
+        let translatedText: String
+        let detectedLanguage: String?
+    }
+
+    enum TranslationError: LocalizedError {
+        case disabled
+        case emptyText
+        case badResponse
+        case noTranslation
+        case networkError(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .disabled:
+                return NSLocalizedString("Translation disabled", comment: "Translation error: feature disabled")
+            case .emptyText:
+                return NSLocalizedString("Nothing to translate", comment: "Translation error: empty text")
+            case .badResponse:
+                return NSLocalizedString("Translation service unavailable", comment: "Translation error: bad response")
+            case .noTranslation:
+                return NSLocalizedString("No translation returned", comment: "Translation error: empty result")
+            case .networkError(let error):
+                return error.localizedDescription
+            }
+        }
+    }
+
+    static let shared = NoteTranslationService()
+
+    private let cache = NSCache<NSString, CachedTranslation>()
+    private let minimumTextLength = 12
+
+    private init() {}
+
+    /// Returns true if the text is long enough, translation is enabled, and the text appears
+    /// to contain translatable content (letters).
+    func shouldOfferTranslation(for text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard NoteTranslationSettings.isEnabled, trimmed.count >= minimumTextLength else { return false }
+        return trimmed.rangeOfCharacter(from: .letters) != nil
+    }
+
+    /// Translate the given text via a LibreTranslate-compatible endpoint.
+    /// Results are cached keyed by (targetLanguage, endpoint, textHash) so toggling
+    /// "Show original" / "Show translation" is instant after the first fetch.
+    func translate(_ text: String) async throws -> TranslationResult {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard NoteTranslationSettings.isEnabled else {
+            throw TranslationError.disabled
+        }
+
+        guard shouldOfferTranslation(for: trimmed) else {
+            throw TranslationError.emptyText
+        }
+
+        let targetLanguage = NoteTranslationSettings.targetLanguage
+        let cacheKey = cacheKey(for: trimmed, targetLanguage: targetLanguage) as NSString
+
+        // Check cache first
+        if let cached = cache.object(forKey: cacheKey) {
+            return TranslationResult(
+                translatedText: cached.translatedText,
+                detectedLanguage: cached.detectedLanguage
+            )
+        }
+
+        // Protect Nostr entities before sending to translation
+        let protectedText = protectEntities(in: trimmed)
+
+        var request = URLRequest(url: NoteTranslationSettings.endpointURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30
+
+        var payload: [String: Any] = [
+            "q": protectedText.text,
+            "source": "auto",
+            "target": targetLanguage,
+            "format": "text"
+        ]
+
+        let apiKey = NoteTranslationSettings.apiKey
+        if !apiKey.isEmpty {
+            payload["api_key"] = apiKey
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (data, response): (Data, URLResponse)
+
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw TranslationError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200 ..< 300).contains(httpResponse.statusCode) else {
+            throw TranslationError.badResponse
+        }
+
+        guard let decoded = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let translated = decoded["translatedText"] as? String else {
+            throw TranslationError.noTranslation
+        }
+
+        let detectedLanguage = detectedLanguage(from: decoded["detectedLanguage"])
+        let restoredText = restoreEntities(in: translated, replacements: protectedText.replacements)
+
+        // Store in cache
+        let cached = CachedTranslation(translatedText: restoredText, detectedLanguage: detectedLanguage)
+        cache.setObject(cached, forKey: cacheKey)
+
+        return TranslationResult(translatedText: restoredText, detectedLanguage: detectedLanguage)
+    }
+}
+
+// MARK: - Entity Protection
+
+private extension NoteTranslationService {
+    struct ProtectedText {
+        let text: String
+        let replacements: [String: String]
+    }
+
+    struct EntityMatch {
+        let range: NSRange
+        let value: String
+    }
+
+    func cacheKey(for text: String, targetLanguage: String) -> String {
+        let raw = "\(targetLanguage)|\(NoteTranslationSettings.endpointURL.absoluteString)|\(text)"
+        guard let data = raw.data(using: .utf8) else { return UUID().uuidString }
+        return data.hash256()
+    }
+
+    /// Replace Nostr entities (npubs, notes, nevents, nprofiles, naddrs, URLs, lightning invoices,
+    /// hashtags, @mentions) with placeholder tokens so the translation service doesn't mangle them.
+    func protectEntities(in text: String) -> ProtectedText {
+        let nsText = text as NSString
+        let patterns = [
+            #"https?://[^\s]+"#,
+            #"nostr:[^\s]+"#,
+            #"\b(?:npub1|nprofile1|note1|nevent1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]+"#,
+            #"\blnbc[0-9a-z]+"#,
+            #"\bbc1[0-9a-z]+"#,
+            #"(?<!\w)#[\p{L}\p{N}_]+"#,
+            #"(?<!\w)@[\p{L}\p{N}_.-]+"#
+        ]
+
+        // Collect all matches
+        let allMatches: [EntityMatch] = {
+            var matches: [EntityMatch] = []
+            for pattern in patterns {
+                guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+                let results = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+                matches.append(contentsOf: results.map {
+                    EntityMatch(range: $0.range, value: nsText.substring(with: $0.range))
+                })
+            }
+            return matches.sorted { $0.range.location < $1.range.location }
+        }()
+
+        // Deduplicate overlapping ranges
+        var selected: [EntityMatch] = []
+        for match in allMatches {
+            guard let previous = selected.last else {
+                selected.append(match)
+                continue
+            }
+            if match.range.location >= previous.range.location + previous.range.length {
+                selected.append(match)
+            }
+        }
+
+        var protectedText = text
+        var replacements: [String: String] = [:]
+
+        for (index, entity) in selected.reversed().enumerated() {
+            let token = "PRIMALENTITY_\(index)"
+            replacements[token] = entity.value
+            protectedText = (protectedText as NSString).replacingCharacters(in: entity.range, with: token)
+        }
+
+        return ProtectedText(text: protectedText, replacements: replacements)
+    }
+
+    func restoreEntities(in text: String, replacements: [String: String]) -> String {
+        var result = text
+        for (token, original) in replacements {
+            result = result.replacingOccurrences(of: token, with: original)
+        }
+        return result
+    }
+
+    func detectedLanguage(from value: Any?) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        if let dictionary = value as? [String: Any] {
+            return dictionary["language"] as? String
+        }
+        return nil
+    }
+}
+
+// MARK: - Cache Object
+
+private final class CachedTranslation {
+    let translatedText: String
+    let detectedLanguage: String?
+
+    init(translatedText: String, detectedLanguage: String?) {
+        self.translatedText = translatedText
+        self.detectedLanguage = detectedLanguage
+    }
+}

--- a/Primal/Common/Views/Feed/PostCell/NoteTranslationView.swift
+++ b/Primal/Common/Views/Feed/PostCell/NoteTranslationView.swift
@@ -1,0 +1,190 @@
+//
+//  NoteTranslationView.swift
+//  Primal
+//
+//  Created for Primal iOS app — inline note translation toggle UI
+//
+
+import UIKit
+
+/// Displays a "Translate" button below note content. After translation, toggles
+/// between the original text and the translated text with a source-language label.
+final class NoteTranslationView: UIStackView {
+    private let translateButton = UIButton(type: .system)
+    private let translatedLabel = UILabel()
+    private let sourceLabel = UILabel()
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
+
+    private var currentText = ""
+    private var currentTask: Task<Void, Never>?
+    private var translationResult: NoteTranslationService.TranslationResult?
+    private var isShowingTranslation = false
+    private var hasError = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Called when a note's content is set. Resets the translation state for the new text.
+    func configure(with text: String) {
+        currentText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        currentTask?.cancel()
+        currentTask = nil
+        translationResult = nil
+        isShowingTranslation = false
+        hasError = false
+
+        translatedLabel.text = nil
+        sourceLabel.text = nil
+        translatedLabel.isHidden = true
+        sourceLabel.isHidden = true
+        activityIndicator.stopAnimating()
+
+        let shouldShow = NoteTranslationService.shared.shouldOfferTranslation(for: currentText)
+        isHidden = !shouldShow
+        translateButton.isEnabled = true
+        translateButton.setTitle(NSLocalizedString("Translate", comment: "Button: translate note"), for: .normal)
+    }
+}
+
+// MARK: - UI Setup
+
+private extension NoteTranslationView {
+    func setup() {
+        axis = .vertical
+        alignment = .fill
+        spacing = 4
+        isHidden = true
+
+        // Translate / Show original / Hide translation button
+        translateButton.contentHorizontalAlignment = .leading
+        translateButton.titleLabel?.font = .appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular)
+        translateButton.tintColor = .accent
+        translateButton.setContentCompressionResistancePriority(.required, for: .vertical)
+        translateButton.addAction(.init(handler: { [weak self] _ in
+            self?.translateTapped()
+        }), for: .touchUpInside)
+
+        // Translated text label
+        translatedLabel.numberOfLines = 0
+        translatedLabel.font = .appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular)
+        translatedLabel.textColor = .foreground
+        translatedLabel.isHidden = true
+
+        // Source language attribution
+        sourceLabel.numberOfLines = 1
+        sourceLabel.font = .appFont(withSize: 12, weight: .regular)
+        sourceLabel.textColor = .foreground3
+        sourceLabel.isHidden = true
+        sourceLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        // Loading indicator
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.color = .foreground3
+
+        addArrangedSubview(translateButton)
+        addArrangedSubview(translatedLabel)
+        addArrangedSubview(sourceLabel)
+        addArrangedSubview(activityIndicator)
+    }
+
+    func translateTapped() {
+        // If we already have a result, toggle display
+        if let result = translationResult {
+            isShowingTranslation.toggle()
+            updateVisibleTranslation(result: result)
+            return
+        }
+
+        // If we had an error, clear it and retry
+        if hasError {
+            hasError = false
+            translateButton.isEnabled = true
+            translateButton.setTitle(NSLocalizedString("Translate", comment: "Button: translate note"), for: .normal)
+        }
+
+        // Guard: don't start duplicate requests
+        guard currentTask == nil else { return }
+
+        translateButton.isEnabled = false
+        translateButton.setTitle(NSLocalizedString("Translating…", comment: "Button: translation in progress"), for: .normal)
+        activityIndicator.startAnimating()
+
+        let textToTranslate = currentText
+        currentTask = Task { [weak self] in
+            do {
+                let result = try await NoteTranslationService.shared.translate(textToTranslate)
+                guard !Task.isCancelled, let self else { return }
+
+                self.translationResult = result
+                self.isShowingTranslation = true
+                self.hasError = false
+                self.currentTask = nil
+
+                await MainActor.run {
+                    self.activityIndicator.stopAnimating()
+                    self.updateVisibleTranslation(result: result)
+                }
+            } catch {
+                guard !Task.isCancelled, let self else { return }
+
+                self.hasError = true
+                self.currentTask = nil
+
+                await MainActor.run {
+                    self.activityIndicator.stopAnimating()
+                    self.translateButton.isEnabled = true
+
+                    let errorMessage: String
+                    if let translationError = error as? NoteTranslationService.TranslationError {
+                        errorMessage = translationError.localizedDescription
+                    } else {
+                        errorMessage = NSLocalizedString("Translation failed", comment: "Error: translation failed")
+                    }
+
+                    self.translatedLabel.text = errorMessage
+                    self.translatedLabel.isHidden = false
+                    self.sourceLabel.isHidden = true
+                    self.translateButton.setTitle(
+                        NSLocalizedString("Retry Translate", comment: "Button: retry note translation"),
+                        for: .normal
+                    )
+                }
+            }
+        }
+    }
+
+    func updateVisibleTranslation(result: NoteTranslationService.TranslationResult) {
+        translatedLabel.text = isShowingTranslation ? result.translatedText : nil
+        translatedLabel.isHidden = !isShowingTranslation
+        activityIndicator.stopAnimating()
+
+        if isShowingTranslation {
+            if let detectedLang = result.detectedLanguage, !detectedLang.isEmpty {
+                let format = NSLocalizedString("Translated from %@", comment: "Translation source attribution, e.g. Translated from ZH")
+                sourceLabel.text = String(format: format, detectedLang.uppercased())
+                sourceLabel.isHidden = false
+            } else {
+                sourceLabel.text = nil
+                sourceLabel.isHidden = true
+            }
+
+            translateButton.setTitle(
+                NSLocalizedString("Show original", comment: "Button: show original note text"),
+                for: .normal
+            )
+        } else {
+            sourceLabel.isHidden = true
+            translateButton.isEnabled = true
+            translateButton.setTitle(
+                NSLocalizedString("Show translation", comment: "Button: show translated note text"),
+                for: .normal
+            )
+        }
+    }
+}

--- a/Primal/Common/Views/Feed/PostCell/PostCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/PostCell.swift
@@ -33,6 +33,7 @@ class PostCell: UITableViewCell {
     let nipLabel = UILabel()
     let replyingToView = ReplyingToView()
     let mainLabel = NantesLabel()
+    let translationView = NoteTranslationView()
     let invoiceView = LightningInvoiceView()
     let mainImages = ImageGalleryView()
     let articleView = ArticleFeedView()
@@ -207,6 +208,7 @@ class PostCell: UITableViewCell {
         }
         
         mainLabel.attributedText = useShortText ? content.attributedTextShort : content.attributedText
+        translationView.configure(with: content.text)
         mainImages.resources = content.mediaResources
         mainImages.thumbnails = content.videoThumbnails
         

--- a/Primal/Common/Views/Feed/PostCell/PostFeedCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/PostFeedCell.swift
@@ -110,7 +110,7 @@ private extension PostFeedCell {
             
         let buttonStackStandIn = UIView()
         let contentStack = UIStackView(axis: .vertical, [
-            nameSuperStack, textStack, invoiceView, articleView, mainImages, linkPresentation, postPreview, zapPreview, infoView, zapGalleryParent, buttonStackStandIn
+            nameSuperStack, textStack, translationView, invoiceView, articleView, mainImages, linkPresentation, postPreview, zapPreview, infoView, zapGalleryParent, buttonStackStandIn
         ])
     
         mainStack.addArrangedSubview(contentStack)

--- a/Primal/Common/Views/Feed/PostCell/ThreadCell.swift
+++ b/Primal/Common/Views/Feed/PostCell/ThreadCell.swift
@@ -150,7 +150,7 @@ final class PostThreadCell: ThreadCell {
         
         let actionButtonStandin = UIView()
         let contentStack = UIStackView(arrangedSubviews: [
-            mainLabel, invoiceView, articleView, mainImages, linkPresentation, postPreview, zapPreview, infoView, smallGallery, SpacerView(height: 0), actionButtonStandin
+            mainLabel, translationView, invoiceView, articleView, mainImages, linkPresentation, postPreview, zapPreview, infoView, smallGallery, SpacerView(height: 0), actionButtonStandin
         ])
         
         let horizontalContentStack = UIStackView(arrangedSubviews: [contentSpacer, contentStack])

--- a/Primal/Scenes/Settings/SettingsMainViewController.swift
+++ b/Primal/Scenes/Settings/SettingsMainViewController.swift
@@ -80,6 +80,7 @@ private extension SettingsMainViewController {
         let appearance = SettingsOptionButton(title: "Appearance")
         let connectedApps = SettingsOptionButton(title: "Connected Apps")
         let contentDisplay = SettingsOptionButton(title: "Content Display")
+        let noteTranslation = SettingsOptionButton(title: "Note Translation")
         let muted = SettingsOptionButton(title: "Muted Content")
         let mediaUploads = SettingsOptionButton(title: "Media Uploads")
         let notifications = SettingsOptionButton(title: "Notifications")
@@ -89,7 +90,7 @@ private extension SettingsMainViewController {
         let versionTitleLabel = SettingsTitleView(title: "VERSION")
         
         let bottomStack = UIStackView(arrangedSubviews: [versionTitleLabel, versionLabel, UIView()])
-        let stack = UIStackView(arrangedSubviews: [keys, wallet, network, appearance, connectedApps, contentDisplay, muted, mediaUploads, notifications, devMode, zaps, SpacerView(height: 40), bottomStack])
+        let stack = UIStackView(arrangedSubviews: [keys, wallet, network, appearance, connectedApps, contentDisplay, noteTranslation, muted, mediaUploads, notifications, devMode, zaps, SpacerView(height: 40), bottomStack])
         
         let scroll = UIScrollView()
         
@@ -147,7 +148,11 @@ private extension SettingsMainViewController {
         contentDisplay.addAction(.init(handler: { [weak self] _ in
             self?.navigationController?.pushViewController(SettingsContentDisplayController(), animated: true)
         }), for: .touchUpInside)
-        
+
+        noteTranslation.addAction(.init(handler: { [weak self] _ in
+            self?.navigationController?.pushViewController(SettingsTranslationViewController(), animated: true)
+        }), for: .touchUpInside)
+
         muted.addAction(.init(handler: { [weak self] _ in
             self?.navigationController?.pushViewController(SettingsMutedViewController(), animated: true)
         }), for: .touchUpInside)

--- a/Primal/Scenes/Settings/SubControllers/SettingsTranslationViewController.swift
+++ b/Primal/Scenes/Settings/SubControllers/SettingsTranslationViewController.swift
@@ -1,0 +1,132 @@
+//
+//  SettingsTranslationViewController.swift
+//  Primal
+//
+//  Created for Primal iOS app — translation settings screen
+//
+
+import UIKit
+
+final class SettingsTranslationViewController: UIViewController, Themeable {
+    private let enabledSwitch = SettingsSwitchView(NSLocalizedString("Enable note translation", comment: "Settings toggle: enable translation"))
+    private let endpointField = UITextField()
+    private let apiKeyField = UITextField()
+    private let languageField = UITextField()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+
+    func updateTheme() {
+        view.backgroundColor = .background
+        navigationItem.leftBarButtonItem = customBackButton
+    }
+}
+
+// MARK: - Setup
+
+private extension SettingsTranslationViewController {
+    func setup() {
+        title = NSLocalizedString("Note Translation", comment: "Settings title")
+
+        let endpointTitle = SettingsTitleViewVibrant(title: NSLocalizedString("TRANSLATION ENDPOINT", comment: "Settings section title"))
+        let endpointFieldContainer = createFieldContainer(endpointField)
+        endpointField.placeholder = NSLocalizedString("https://libretranslate.com/translate", comment: "Endpoint placeholder")
+        endpointField.text = NoteTranslationSettings.endpointURL.absoluteString
+        endpointField.autocapitalizationType = .none
+        endpointField.autocorrectionType = .no
+        endpointField.keyboardType = .URL
+        endpointField.addAction(.init(handler: { [weak self] _ in
+            if let text = self?.endpointField.text, let url = URL(string: text) {
+                NoteTranslationSettings.endpointURL = url
+            }
+        }), for: .editingDidEnd)
+
+        let endpointDesc = descLabel(
+            NSLocalizedString("A LibreTranslate-compatible endpoint URL. Defaults to libretranslate.com. Self-hosted instances are recommended for privacy.", comment: "Settings description")
+        )
+
+        let apiKeyTitle = SettingsTitleViewVibrant(title: NSLocalizedString("API KEY (optional)", comment: "Settings section title"))
+        let apiKeyContainer = createFieldContainer(apiKeyField)
+        apiKeyField.placeholder = NSLocalizedString("Optional API key", comment: "API key placeholder")
+        apiKeyField.text = NoteTranslationSettings.apiKey.isEmpty ? nil : NoteTranslationSettings.apiKey
+        apiKeyField.autocapitalizationType = .none
+        apiKeyField.autocorrectionType = .no
+        apiKeyField.isSecureTextEntry = true
+        apiKeyField.addAction(.init(handler: { [weak self] _ in
+            NoteTranslationSettings.apiKey = self?.apiKeyField.text ?? ""
+        }), for: .editingDidEnd)
+
+        let apiKeyDesc = descLabel(
+            NSLocalizedString("Required if your endpoint requires authentication. Leave empty for public instances.", comment: "Settings description")
+        )
+
+        let langTitle = SettingsTitleViewVibrant(title: NSLocalizedString("TARGET LANGUAGE", comment: "Settings section title"))
+        let langContainer = createFieldContainer(languageField)
+        languageField.placeholder = NSLocalizedString("e.g. en, zh, es, fr, de", comment: "Language code placeholder")
+        languageField.text = NoteTranslationSettings.targetLanguage
+        languageField.autocapitalizationType = .none
+        languageField.autocorrectionType = .no
+        languageField.addAction(.init(handler: { [weak self] _ in
+            if let text = self?.languageField.text, !text.isEmpty {
+                NoteTranslationSettings.targetLanguage = text
+            }
+        }), for: .editingDidEnd)
+
+        let langDesc = descLabel(
+            NSLocalizedString("ISO 639-1 language code (e.g. en, zh, es). Defaults to your device language.", comment: "Settings description")
+        )
+
+        // Wire up the enabled switch
+        enabledSwitch.switchView.isOn = NoteTranslationSettings.isEnabled
+        enabledSwitch.switchView.addAction(.init(handler: { [weak self] _ in
+            guard let value = self?.enabledSwitch.switchView.isOn else { return }
+            NoteTranslationSettings.isEnabled = value
+        }), for: .valueChanged)
+
+        let stack = UIStackView(axis: .vertical, [
+            enabledSwitch, SpacerView(height: 10),
+            endpointTitle, SpacerView(height: 12),
+            endpointFieldContainer, SpacerView(height: 6),
+            endpointDesc, SpacerView(height: 24),
+            apiKeyTitle, SpacerView(height: 12),
+            apiKeyContainer, SpacerView(height: 6),
+            apiKeyDesc, SpacerView(height: 24),
+            langTitle, SpacerView(height: 12),
+            langContainer, SpacerView(height: 6),
+            langDesc, SpacerView(height: 32)
+        ])
+
+        let scroll = UIScrollView()
+        view.addSubview(scroll)
+        scroll
+            .pinToSuperview(edges: .horizontal)
+            .pinToSuperview(edges: .bottom, padding: 56, safeArea: true)
+            .pinToSuperview(edges: .top, padding: 7, safeArea: true)
+
+        scroll.addSubview(stack)
+        stack.pinToSuperview(edges: .horizontal, padding: 20).pinToSuperview(edges: .vertical, padding: 38)
+        stack.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -40).isActive = true
+
+        updateTheme()
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tap)
+    }
+
+    func createFieldContainer(_ field: UITextField) -> UIView {
+        let container = ThemeableView().constrainToSize(height: 48)
+        container.setTheme { $0.backgroundColor = .background3 }
+        container.layer.cornerRadius = 24
+        container.addSubview(field)
+        field.pinToSuperview(edges: .horizontal, padding: 16).centerToSuperview()
+        field.font = .appFont(withSize: 16, weight: .regular)
+        field.textColor = .foreground
+        return container
+    }
+
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/add_files_to_project.rb
+++ b/add_files_to_project.rb
@@ -1,0 +1,48 @@
+require 'xcodeproj'
+
+project_path = '/Users/eric/Desktop/herness/primal-ios-app/Primal.xcodeproj'
+project = Xcodeproj::Project.open(project_path)
+
+# Find the main group and target
+main_group = project.main_group
+target = project.targets.first
+
+# Helper to find or create groups recursively
+def find_or_create_group(parent, path_components)
+  return parent if path_components.empty?
+  name = path_components.first
+  child = parent.children.find { |c| c.is_a?(Xcodeproj::Project::PBXGroup) && c.name == name }
+  child ||= parent.new_group(name)
+  find_or_create_group(child, path_components[1..])
+end
+
+# Files to add: [disk_path, group_path]
+files_to_add = [
+  ['Primal/Common/Views/Feed/PostCell/NoteTranslationService.swift', 'Primal/Common/Views/Feed/PostCell'],
+  ['Primal/Common/Views/Feed/PostCell/NoteTranslationView.swift', 'Primal/Common/Views/Feed/PostCell'],
+  ['Primal/Scenes/Settings/SubControllers/SettingsTranslationViewController.swift', 'Primal/Scenes/Settings/SubControllers'],
+]
+
+files_to_add.each do |disk_path, group_path|
+  # Check if already in project
+  existing = project.files.find { |f| f.path == disk_path }
+  if existing
+    puts "Already in project: #{disk_path}"
+    next
+  end
+
+  # Navigate to the right group
+  components = group_path.split('/')
+  group = find_or_create_group(main_group, components)
+  
+  # Create file reference
+  file = group.new_file(disk_path)
+  
+  # Add to target's sources build phase
+  target.source_build_phase.add_file_reference(file)
+  
+  puts "Added: #{disk_path}"
+end
+
+project.save
+puts "Project saved successfully!"


### PR DESCRIPTION
Implements inline note translation using LibreTranslate API.

**Changes:**
- NoteTranslationService: entity protection (nostr:npub/nprofile/URLs/lnbc/hashtags/@mentions), content hash caching, async/await LibreTranslate API
- NoteTranslationView: Translate button + translated text label + source language indicator + loading/error states
- SettingsTranslationViewController: Enable/disable toggle, endpoint URL, API key, target language config
- PostFeedCell/ThreadCell: translationView integrated into content stack
- SettingsMainViewController: Note Translation menu entry

Based on the existing PR#208 work, completes the missing settings UI and view integration.

Closes #208