### PR TITLE
feat: translate notes to user's preferred language (#206)

### DIFF
--- a/Primal.xcodeproj/project.pbxproj
+++ b/Primal.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		933B85772A9F6EE300C48FF6 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933B85762A9F6EE300C48FF6 /* Utils.swift */; };
 		933DBDBD2A1145A1008DCF1F /* StringProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933DBDBC2A1145A1008DCF1F /* StringProtocol.swift */; };
 		933DBDBF2A11FF87008DCF1F /* ParsedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933DBDBE2A11FF87008DCF1F /* ParsedContent.swift */; };
+		E2F3A4B5C6D718293A4B5C6E /* NoteTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C60718293A4B5D /* NoteTranslation.swift */; };
 		9344DB312A1D28EB00C9F281 /* NostrKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9344DB302A1D28EB00C9F281 /* NostrKind.swift */; };
 		9363DE712A30DD9E0060F4BD /* DeeplinkHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363DE702A30DD9E0060F4BD /* DeeplinkHandlerProtocol.swift */; };
 		9363DE732A30DDB90060F4BD /* DeeplinkHandlerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363DE722A30DDB90060F4BD /* DeeplinkHandlerCoordinator.swift */; };
@@ -697,6 +698,7 @@
 		B9E67E262EFC1106002D7952 /* PushNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E67E252EFC1100002D7952 /* PushNotificationsManager.swift */; };
 		B9E67E7D2D075E35006BB397 /* FeedElementUserCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E67E7C2D075E35006BB397 /* FeedElementUserCell.swift */; };
 		B9E67E7F2D0760B6006BB397 /* FeedElementTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E67E7E2D0760B6006BB397 /* FeedElementTextCell.swift */; };
+		A4B5C6D7E8F91A2B3C4D5E6F0 /* NoteTranslateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A4B5C6D7E8192A4B5C6D7F /* NoteTranslateView.swift */; };
 		B9E67E812D0762CD006BB397 /* FeedElementSmallZapGalleryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E67E802D0762CD006BB397 /* FeedElementSmallZapGalleryCell.swift */; };
 		B9E67E832D076303006BB397 /* FeedElementImageGalleryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E67E822D076303006BB397 /* FeedElementImageGalleryCell.swift */; };
 		B9E67E852D076327006BB397 /* FeedElementWebPreviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E67E842D076327006BB397 /* FeedElementWebPreviewCell.swift */; };
@@ -862,6 +864,7 @@
 		933B85762A9F6EE300C48FF6 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		933DBDBC2A1145A1008DCF1F /* StringProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocol.swift; sourceTree = "<group>"; };
 		933DBDBE2A11FF87008DCF1F /* ParsedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsedContent.swift; sourceTree = "<group>"; };
+		D1E2F3A4B5C60718293A4B5D /* NoteTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTranslation.swift; sourceTree = "<group>"; };
 		9344DB302A1D28EB00C9F281 /* NostrKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrKind.swift; sourceTree = "<group>"; };
 		9363DE702A30DD9E0060F4BD /* DeeplinkHandlerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandlerProtocol.swift; sourceTree = "<group>"; };
 		9363DE722A30DDB90060F4BD /* DeeplinkHandlerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandlerCoordinator.swift; sourceTree = "<group>"; };
@@ -1554,6 +1557,7 @@
 		B9E67E252EFC1100002D7952 /* PushNotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsManager.swift; sourceTree = "<group>"; };
 		B9E67E7C2D075E35006BB397 /* FeedElementUserCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedElementUserCell.swift; sourceTree = "<group>"; };
 		B9E67E7E2D0760B6006BB397 /* FeedElementTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedElementTextCell.swift; sourceTree = "<group>"; };
+		F3A4B5C6D7E8192A4B5C6D7F /* NoteTranslateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTranslateView.swift; sourceTree = "<group>"; };
 		B9E67E802D0762CD006BB397 /* FeedElementSmallZapGalleryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedElementSmallZapGalleryCell.swift; sourceTree = "<group>"; };
 		B9E67E822D076303006BB397 /* FeedElementImageGalleryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedElementImageGalleryCell.swift; sourceTree = "<group>"; };
 		B9E67E842D076327006BB397 /* FeedElementWebPreviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedElementWebPreviewCell.swift; sourceTree = "<group>"; };
@@ -1748,6 +1752,7 @@
 			isa = PBXGroup;
 			children = (
 				933DBDBE2A11FF87008DCF1F /* ParsedContent.swift */,
+				D1E2F3A4B5C60718293A4B5D /* NoteTranslation.swift */,
 			);
 			path = Notes;
 			sourceTree = "<group>";
@@ -3714,6 +3719,7 @@
 				B9E67E972D088BDA006BB397 /* Thread */,
 				B9E67E7C2D075E35006BB397 /* FeedElementUserCell.swift */,
 				B9E67E7E2D0760B6006BB397 /* FeedElementTextCell.swift */,
+				F3A4B5C6D7E8192A4B5C6D7F /* NoteTranslateView.swift */,
 				B9E67E802D0762CD006BB397 /* FeedElementSmallZapGalleryCell.swift */,
 				B9E67E822D076303006BB397 /* FeedElementImageGalleryCell.swift */,
 				AAA1110000000000000B000A /* FeedElementAudioCell.swift */,
@@ -4443,6 +4449,7 @@
 				B9DAA4582D4A61D400B00B82 /* NWCScheme.swift in Sources */,
 				B914CD6B2AA20DC400CD0BD1 /* MutedUserCell.swift in Sources */,
 				933DBDBF2A11FF87008DCF1F /* ParsedContent.swift in Sources */,
+				E2F3A4B5C6D718293A4B5C6E /* NoteTranslation.swift in Sources */,
 				B9E67EAA2D09D8FA006BB397 /* ThreadElementUserCell.swift in Sources */,
 				B91E56E82CB9843A00C14809 /* AdvancedSearchMenuItemView.swift in Sources */,
 				B9E67E7D2D075E35006BB397 /* FeedElementUserCell.swift in Sources */,
@@ -4468,6 +4475,7 @@
 				9E9F2F8029F6AB6400A9CDF3 /* IntroVideoController.swift in Sources */,
 				B91EF0CF2CEA1B6F00299ECF /* PremiumManageContentDataCell.swift in Sources */,
 				B9E67E7F2D0760B6006BB397 /* FeedElementTextCell.swift in Sources */,
+				A4B5C6D7E8F91A2B3C4D5E6F0 /* NoteTranslateView.swift in Sources */,
 				B91EF0DD2CEBA30400299ECF /* LegendTheme.swift in Sources */,
 				B906AB0B2C9A10DE0089813F /* ProfileCounts.swift in Sources */,
 				93EAED182ABB25B300B4A1CD /* Collection+Extra.swift in Sources */,

--- a/Primal/Common/Notes/NoteTranslation.swift
+++ b/Primal/Common/Notes/NoteTranslation.swift
@@ -1,0 +1,191 @@
+//
+//  NoteTranslation.swift
+//  Primal
+//
+//  Created by indrad3v4 on 6.8.26..
+//
+
+import Foundation
+
+// Translation of note content into the user's preferred language.
+//
+// Uses free, keyless public translation endpoints, so no API key is required:
+// the public LibreTranslate instances are tried first and, if none of them is
+// reachable, we fall back to the free Google Translate endpoint
+// (translate.googleapis.com), which requires no key.
+
+enum TranslationEngine {
+    case libreTranslate, google
+}
+
+struct TranslationResult {
+    let text: String
+    let engine: TranslationEngine
+}
+
+struct TranslationLanguage {
+    let code: String
+    let name: String
+}
+
+enum NoteTranslation {
+    private static let storageKey = "primal_translate_lang"
+    
+    private static let libreTranslateInstances = [
+        "https://libretranslate.com/translate",
+        "https://translate.terraprint.co/translate",
+        "https://libretranslate.pussthecat.org/translate",
+        "https://lt.vern.cc/translate",
+    ]
+    
+    private static let googleTranslateURL = "https://translate.googleapis.com/translate_a/single"
+    
+    // In-memory cache of translated notes: noteID -> (target language, result),
+    // so toggling between the original and the translation is instant.
+    private static var cache: [String: (target: String, result: TranslationResult)] = [:]
+    
+    // A curated list of the most common target languages.
+    // Codes are ISO 639-1 (LibreTranslate style); Google-specific variants
+    // (zh-Hans, nb) are mapped to their Google equivalents when used.
+    static let languages: [TranslationLanguage] = [
+        TranslationLanguage(code: "en", name: "English"),
+        TranslationLanguage(code: "es", name: "Spanish"),
+        TranslationLanguage(code: "fr", name: "French"),
+        TranslationLanguage(code: "de", name: "German"),
+        TranslationLanguage(code: "it", name: "Italian"),
+        TranslationLanguage(code: "pt", name: "Portuguese"),
+        TranslationLanguage(code: "nl", name: "Dutch"),
+        TranslationLanguage(code: "ru", name: "Russian"),
+        TranslationLanguage(code: "uk", name: "Ukrainian"),
+        TranslationLanguage(code: "pl", name: "Polish"),
+        TranslationLanguage(code: "cs", name: "Czech"),
+        TranslationLanguage(code: "sk", name: "Slovak"),
+        TranslationLanguage(code: "sv", name: "Swedish"),
+        TranslationLanguage(code: "nb", name: "Norwegian"),
+        TranslationLanguage(code: "da", name: "Danish"),
+        TranslationLanguage(code: "fi", name: "Finnish"),
+        TranslationLanguage(code: "el", name: "Greek"),
+        TranslationLanguage(code: "tr", name: "Turkish"),
+        TranslationLanguage(code: "ar", name: "Arabic"),
+        TranslationLanguage(code: "he", name: "Hebrew"),
+        TranslationLanguage(code: "hi", name: "Hindi"),
+        TranslationLanguage(code: "bn", name: "Bengali"),
+        TranslationLanguage(code: "th", name: "Thai"),
+        TranslationLanguage(code: "vi", name: "Vietnamese"),
+        TranslationLanguage(code: "id", name: "Indonesian"),
+        TranslationLanguage(code: "ja", name: "Japanese"),
+        TranslationLanguage(code: "ko", name: "Korean"),
+        TranslationLanguage(code: "zh-Hans", name: "Chinese (Simplified)"),
+    ]
+    
+    // Defaults to the device language; falls back to English when it isn't
+    // one of the supported languages.
+    static func defaultTargetLanguage() -> String {
+        let deviceLanguage = Locale.preferredLanguages.first ?? "en"
+        let base = deviceLanguage.split(separator: "-").first.map(String.init)?.lowercased() ?? "en"
+        let normalized = base == "zh" ? "zh-Hans" : base
+        return languages.contains(where: { $0.code == normalized }) ? normalized : "en"
+    }
+    
+    static var targetLanguage: String {
+        get {
+            if let stored = UserDefaults.standard.string(forKey: storageKey),
+               languages.contains(where: { $0.code == stored }) {
+                return stored
+            }
+            return defaultTargetLanguage()
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: storageKey)
+        }
+    }
+    
+    static func cachedTranslation(for noteID: String) -> TranslationResult? {
+        guard let cached = cache[noteID], cached.target == targetLanguage else { return nil }
+        return cached.result
+    }
+    
+    static func cacheTranslation(_ result: TranslationResult, for noteID: String) {
+        cache[noteID] = (targetLanguage, result)
+    }
+    
+    static func translate(_ text: String) async -> TranslationResult? {
+        let target = targetLanguage
+        
+        if let libreText = await translateViaLibreTranslate(text, target: target) {
+            return TranslationResult(text: libreText, engine: .libreTranslate)
+        }
+        
+        if let googleText = await translateViaGoogle(text, target: target) {
+            return TranslationResult(text: googleText, engine: .google)
+        }
+        
+        return nil
+    }
+    
+    private static func translateViaLibreTranslate(_ text: String, target: String) async -> String? {
+        for instance in libreTranslateInstances {
+            guard let url = URL(string: instance) else { continue }
+            
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.timeoutInterval = 10
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONSerialization.data(withJSONObject: [
+                "q": text,
+                "source": "auto",
+                "target": target,
+                "format": "text",
+            ])
+            
+            guard
+                let (data, response) = try? await URLSession.shared.data(for: request),
+                (response as? HTTPURLResponse)?.statusCode == 200,
+                let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                let translated = json["translatedText"] as? String,
+                !translated.isEmpty
+            else { continue }
+            
+            return translated
+        }
+        
+        return nil
+    }
+    
+    private static func googleTarget(_ target: String) -> String {
+        switch target {
+        case "zh-Hans": return "zh-CN"
+        case "nb":      return "no"
+        default:        return target
+        }
+    }
+    
+    private static func translateViaGoogle(_ text: String, target: String) async -> String? {
+        guard var components = URLComponents(string: googleTranslateURL) else { return nil }
+        
+        components.queryItems = [
+            URLQueryItem(name: "client", value: "gtx"),
+            URLQueryItem(name: "sl", value: "auto"),
+            URLQueryItem(name: "tl", value: googleTarget(target)),
+            URLQueryItem(name: "dt", value: "t"),
+            URLQueryItem(name: "q", value: text),
+        ]
+        
+        guard let url = components.url else { return nil }
+        
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        
+        guard
+            let (data, response) = try? await URLSession.shared.data(for: request),
+            (response as? HTTPURLResponse)?.statusCode == 200,
+            let json = (try? JSONSerialization.jsonObject(with: data)) as? [Any],
+            let first = json.first as? [Any],
+            let second = first.first as? [Any],
+            let translated = second.first as? String,
+            !translated.isEmpty
+        else { return nil }
+        
+        return translated
+    }
+}

--- a/Primal/Scenes/Feed/FeedElementCells/FeedElementTextCell.swift
+++ b/Primal/Scenes/Feed/FeedElementCells/FeedElementTextCell.swift
@@ -28,8 +28,9 @@ class FeedElementTextCell: FeedElementBaseCell, RegularFeedElementCell {
     let nantesDelegate = FeedElementTextCellNantesDelegate()
     
     let mainLabel = NantesLabel()
+    let translateView = NoteTranslateView()
     lazy var seeMoreLabel = UILabel("See more...", color: .accent2, font: .appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular))
-    lazy var textStack = UIStackView(arrangedSubviews: [mainLabel, seeMoreLabel])
+    lazy var textStack = UIStackView(arrangedSubviews: [mainLabel, seeMoreLabel, translateView])
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -45,6 +46,8 @@ class FeedElementTextCell: FeedElementBaseCell, RegularFeedElementCell {
         
         seeMoreLabel.isHidden = !(mainLabel.isTruncated() || (mainLabel.attributedText?.length ?? 0) == 500)
         
+        translateView.update(with: parsedContent)
+        
         updateTheme()
     }
     
@@ -56,6 +59,8 @@ class FeedElementTextCell: FeedElementBaseCell, RegularFeedElementCell {
         
         textStack.spacing = FontSizeSelection.current.contentLineSpacing
         mainLabel.font = UIFont.appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular)
+        
+        translateView.updateTheme()
     }
 }
 

--- a/Primal/Scenes/Feed/FeedElementCells/NoteTranslateView.swift
+++ b/Primal/Scenes/Feed/FeedElementCells/NoteTranslateView.swift
@@ -1,0 +1,150 @@
+//
+//  NoteTranslateView.swift
+//  Primal
+//
+//  Created by indrad3v4 on 6.8.26..
+//
+
+import UIKit
+
+// "Translate" button shown under note content. Translates the note into the
+// user's preferred language (see NoteTranslation) and shows the result inline
+// with attribution and a "Show original" toggle, similar to the web app.
+final class NoteTranslateView: UIView {
+    private let translateButton = UIButton(type: .system)
+    private let translatedLabel = UILabel()
+    private let attributionLabel = UILabel()
+    private let showOriginalButton = UIButton(type: .system)
+    private let errorLabel = UILabel()
+    
+    private lazy var translatedStack = UIStackView(axis: .vertical, [translatedLabel, metaStack])
+    private lazy var metaStack = UIStackView([attributionLabel, showOriginalButton])
+    
+    private var noteID: String?
+    private var noteText = ""
+    private var isTranslating = false
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func update(with content: ParsedContent) {
+        // Keep the current state while the cell is reused for the same note.
+        if noteID == content.post.id { return }
+        
+        noteID = content.post.id
+        noteText = content.text
+        
+        isHidden = content.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        
+        if let cached = NoteTranslation.cachedTranslation(for: content.post.id) {
+            showTranslated(cached)
+        } else {
+            showButton()
+        }
+    }
+    
+    func updateTheme() {
+        translateButton.setTitleColor(.accent2, for: .normal)
+        showOriginalButton.setTitleColor(.accent2, for: .normal)
+        translatedLabel.textColor = .foreground
+        attributionLabel.textColor = .foreground3
+        errorLabel.textColor = .foreground3
+    }
+    
+    private func translate() {
+        guard let noteID, !isTranslating, !noteText.isEmpty else { return }
+        
+        if let cached = NoteTranslation.cachedTranslation(for: noteID) {
+            showTranslated(cached)
+            return
+        }
+        
+        let targetNoteID = noteID
+        let text = noteText
+        
+        isTranslating = true
+        translateButton.setTitle("Translating…", for: .normal)
+        translateButton.isEnabled = false
+        
+        Task { @MainActor [weak self] in
+            let result = await NoteTranslation.translate(text)
+            
+            guard let self, self.noteID == targetNoteID else { return }
+            
+            self.isTranslating = false
+            self.translateButton.setTitle("Translate", for: .normal)
+            self.translateButton.isEnabled = true
+            
+            if let result {
+                NoteTranslation.cacheTranslation(result, for: targetNoteID)
+                self.showTranslated(result)
+            } else {
+                self.showError()
+            }
+        }
+    }
+    
+    private func showButton() {
+        translatedStack.isHidden = true
+        errorLabel.isHidden = true
+        translateButton.isHidden = false
+    }
+    
+    private func showTranslated(_ result: TranslationResult) {
+        translatedLabel.text = result.text
+        attributionLabel.text = result.engine == .google ? "Translated by Google Translate" : "Translated by LibreTranslate"
+        translateButton.isHidden = true
+        errorLabel.isHidden = true
+        translatedStack.isHidden = false
+    }
+    
+    private func showError() {
+        translateButton.isHidden = true
+        translatedStack.isHidden = true
+        errorLabel.isHidden = false
+    }
+}
+
+private extension NoteTranslateView {
+    func setup() {
+        let stack = UIStackView(axis: .vertical, [translateButton, translatedStack, errorLabel])
+        stack.spacing = 6
+        addSubview(stack)
+        stack.pinToSuperview()
+        
+        translateButton.setTitle("Translate", for: .normal)
+        translateButton.titleLabel?.font = .appFont(withSize: 14, weight: .regular)
+        translateButton.contentHorizontalAlignment = .leading
+        translateButton.addAction(.init(handler: { [weak self] _ in
+            self?.translate()
+        }), for: .touchUpInside)
+        
+        translatedLabel.numberOfLines = 0
+        translatedLabel.font = .appFont(withSize: FontSizeSelection.current.contentFontSize, weight: .regular)
+        
+        metaStack.spacing = 8
+        attributionLabel.font = .appFont(withSize: 13, weight: .regular)
+        attributionLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        
+        showOriginalButton.setTitle("Show original", for: .normal)
+        showOriginalButton.titleLabel?.font = .appFont(withSize: 13, weight: .regular)
+        showOriginalButton.addAction(.init(handler: { [weak self] _ in
+            self?.showButton()
+        }), for: .touchUpInside)
+        
+        errorLabel.text = "Translation is unavailable right now. Please try again later."
+        errorLabel.numberOfLines = 0
+        errorLabel.font = .appFont(withSize: 13, weight: .regular)
+        
+        translatedStack.isHidden = true
+        errorLabel.isHidden = true
+        
+        updateTheme()
+    }
+}

--- a/Primal/Scenes/Feed/FeedElementCells/Thread/MainThreadCells/MainThreadElementTextCell.swift
+++ b/Primal/Scenes/Feed/FeedElementCells/Thread/MainThreadCells/MainThreadElementTextCell.swift
@@ -16,6 +16,7 @@ class MainThreadElementTextCell: FeedElementBaseCell, RegularFeedElementCell {
     var useShortText: Bool { true }
 
     let selectionTextView = UITextView()
+    let translateView = NoteTranslateView()
 
     var heightC: NSLayoutConstraint?
 
@@ -36,11 +37,15 @@ class MainThreadElementTextCell: FeedElementBaseCell, RegularFeedElementCell {
         heightC?.priority = .defaultHigh
         heightC?.isActive = true
 
+        translateView.update(with: parsedContent)
+        
         updateTheme()
     }
 
     override func updateTheme() {
         super.updateTheme()
+        
+        translateView.updateTheme()
     }
 }
 
@@ -50,7 +55,12 @@ private extension MainThreadElementTextCell {
         selectionTextView
             .pinToSuperview(edges: .horizontal, padding: -5)
             .pinToSuperview(edges: .top, padding: 3)
-            .pinToSuperview(edges: .bottom, padding: -5)
+
+        contentContainer.addSubview(translateView)
+        translateView
+            .pinToSuperview(edges: .horizontal, padding: 4)
+            .pinToSuperview(edges: .bottom)
+        translateView.topAnchor.constraint(equalTo: selectionTextView.bottomAnchor, constant: 2).isActive = true
 
         selectionTextView.backgroundColor = .clear
         selectionTextView.linkTextAttributes = [:]

--- a/Primal/Scenes/Settings/SubControllers/SettingsAppearanceViewController.swift
+++ b/Primal/Scenes/Settings/SubControllers/SettingsAppearanceViewController.swift
@@ -67,6 +67,19 @@ private extension SettingsAppearanceViewController {
             ThemingManager.instance.setStartingTheme()
         }), for: .valueChanged)
         
+        let translateRow = SettingsOptionButton(title: "Translation Language: \(NoteTranslation.languages.first(where: { $0.code == NoteTranslation.targetLanguage })?.name ?? "English")")
+        translateRow.addAction(.init(handler: { [weak self] _ in
+            guard let self else { return }
+            let names = NoteTranslation.languages.map(\.name)
+            let startingIndex = NoteTranslation.languages.firstIndex(where: { $0.code == NoteTranslation.targetLanguage }) ?? 0
+            let picker = PopupUIPickerController(options: names, startingIndex: startingIndex) { name in
+                guard let language = NoteTranslation.languages.first(where: { $0.name == name }) else { return }
+                NoteTranslation.targetLanguage = language.code
+                translateRow.label.text = "Translation Language: \(language.name)"
+            }
+            self.present(picker, animated: true)
+        }), for: .touchUpInside)
+        
         previewTable.dataSource = self
         previewTable.isUserInteractionEnabled = false
         previewTable.backgroundColor = .clear
@@ -85,6 +98,9 @@ private extension SettingsAppearanceViewController {
             SettingsTitleViewVibrant(title: "FONT"), SpacerView(height: 22, priority: .defaultLow),
             slider, SpacerView(height: 20, priority: .defaultHigh),
             BorderView(), SpacerView(height: 16, priority: .defaultHigh),
+            SettingsTitleViewVibrant(title: "TRANSLATION"), SpacerView(height: 12, priority: .defaultLow),
+            translateRow, SpacerView(height: 20, priority: .defaultHigh),
+            BorderView(), SpacerView(height: 16, priority: .defaultHigh),
 //            SettingsTitleViewVibrant(title: "LAYOUT"),      SpacerView(height: 12, priority: .defaultLow),
 //            toggle,                                         SpacerView(height: 16, priority: .defaultHigh),
 //            BorderView(),                                   SpacerView(height: 16, priority: .defaultHigh),
@@ -102,7 +118,7 @@ private extension SettingsAppearanceViewController {
         scrollView.addSubview(stack)
         stack.pinToSuperview()
         stack.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
-        stack.heightAnchor.constraint(equalToConstant: 650).isActive = true
+        stack.heightAnchor.constraint(equalToConstant: 760).isActive = true
         
         updateTheme()
     }


### PR DESCRIPTION
Closes #206 — Translate notes to user's preferred language

Adds a **Translate** button on notes (feed, thread, single views). Uses free keyless translation (LibreTranslate public instances → Google Translate fallback, no API key required), a language preference in Settings → Appearance → Translation (28 languages, defaults to device language), and an in-memory per-note cache so toggling is instant. Translated notes show attribution + "Show original".

Mirrors the web implementation (primal-web-app #212).
