### PR TITLE
Give NewPostButton an accessibilityIdentifier

### DIFF
--- a/Primal/Common/Views/Feed/NewPostButton.swift
+++ b/Primal/Common/Views/Feed/NewPostButton.swift
@@ -17,6 +17,9 @@ class NewPostButton: UIButton, Themeable {
     init() {
         super.init(frame: .zero)
         constrainToSize(56)
+        // Stable handle for UI automation. The button is icon-only, so it carries no
+        // title for a test to match on; this is invisible to users and to VoiceOver.
+        accessibilityIdentifier = "newPostButton"
         updateTheme()
     }
 


### PR DESCRIPTION
### Give `NewPostButton` an `accessibilityIdentifier`

Three lines, one file. It adds a stable name that UI automation can use to find the new-post button. Nothing about the app's appearance or behaviour changes.

```swift
accessibilityIdentifier = "newPostButton"
```

#### What this is for

We are adding an automated smoke test that launches the app and taps the new-post button. To tap something, a UI test has to be able to *find* it first — and it finds elements by asking the accessibility tree for a name.

`accessibilityIdentifier` is exactly that name. It is a developer-facing string: it is **not** spoken by VoiceOver, not shown anywhere in the UI, and has no effect on layout, theming or behaviour. Its only reader is automation. (VoiceOver reads `accessibilityLabel`, which this PR does not touch.)

#### Why the button cannot be found today

`NewPostButton` is icon-only. Its configuration sets an image (`addPostPlus`) and no title:

```swift
config.image = UIImage(named: "addPostPlus")?.withRenderingMode(.alwaysTemplate)
```

A button with no title contributes no text to the accessibility tree, and nothing in the class sets a label or an identifier. Measured against `6fde0f02` (main at the time of writing), the button appears in the tree with **empty accessibility text and an empty resource-id** — so there is no string a test can ask for. It is visually obvious and programmatically anonymous.

There is currently no `accessibilityIdentifier` or `accessibilityLabel` anywhere in the project, so this is the first one; the value follows the class name in lowerCamelCase, which is the usual iOS convention and an easy pattern to extend if more are needed later.

#### Why not one of the usual workarounds

Both alternatives were considered and rejected for the same underlying reason — **they fail without going red**, which is worse than not having the test at all.

**Tapping fixed coordinates.** The button sits at a known corner, so a test could tap that point. But a coordinate tap succeeds whether or not anything is there. Move the button, change its padding, or run on a different screen size, and the tap lands on empty space or on whatever is now underneath — and the test still reports a pass. It would go on passing long after it stopped exercising the thing it names.

**Selecting by position in the tree** (*"the third button on screen"*). This resolves reliably, which is the problem: after any change to the view hierarchy it still resolves, just to a *different element*. The test keeps running, keeps passing, and quietly tests something else.

An identifier fails the other way. If it is renamed or removed, the lookup finds nothing and the test fails immediately and loudly — which is the behaviour we want from a check whose whole job is to notice when something breaks.

#### Scope

This unblocks one automated test. It changes nothing else — no behaviour, no appearance, no accessibility semantics for users. It is independent of anything else we may have open against this repo, and can be reviewed and merged entirely on its own.
